### PR TITLE
Add thumbnail layout to post cards

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -67,6 +67,35 @@
     display: block;
 }
 
+.gh-card-link-image {
+    display: flex;
+    gap: 2.4rem;
+    align-items: stretch;
+}
+
+.gh-card-media {
+    position: relative;
+    flex: 0 0 12rem;
+    width: 12rem;
+    aspect-ratio: 1 / 1;
+    margin: 0;
+    overflow: hidden;
+    border-radius: 1.2rem;
+    background-color: var(--color-light-gray);
+}
+
+.gh-card-thumbnail {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.gh-card-content {
+    flex: 1 1 auto;
+}
+
 .gh-card-link:hover {
     opacity: 1;
 }
@@ -570,6 +599,15 @@
 @media (max-width: 767px) {
     .gh-latest {
         margin-bottom: 8rem;
+    }
+
+    .gh-card-link-image {
+        flex-direction: column;
+    }
+
+    .gh-card-media {
+        width: 100%;
+        max-width: none;
     }
 
     .gh-wrapper {

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -1,20 +1,33 @@
 <article class="gh-card {{post_class}}">
-    <a class="gh-card-link" href="{{url}}">
-        <header class="gh-card-header">
-            <h2 class="gh-card-title">{{title}}</h2>
-        </header>
+    <a class="gh-card-link{{#if feature_image}} gh-card-link-image{{/if}}" href="{{url}}">
+        {{#if feature_image}}
+            <figure class="gh-card-media">
+                <img
+                    class="gh-card-thumbnail"
+                    src="{{img_url feature_image size="s"}}"
+                    alt="{{title}}"
+                    loading="lazy"
+                >
+            </figure>
+        {{/if}}
 
-        <div class="gh-card-excerpt">{{excerpt}}</div>
+        <div class="gh-card-content">
+            <header class="gh-card-header">
+                <h2 class="gh-card-title">{{title}}</h2>
+            </header>
 
-        <footer class="gh-card-meta">
-            <time class="gh-card-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="DD MMM YYYY"}}</time>
-            <span class="gh-card-duration">{{reading_time}}</span>
-            {{#if @site.comments_enabled}}
-                {{comment_count class="gh-card-comments"}}
-            {{/if}}
-            {{^has visibility="public"}}
-                {{> icons/star}}
-            {{/has}}
-        </footer>
+            <div class="gh-card-excerpt">{{excerpt}}</div>
+
+            <footer class="gh-card-meta">
+                <time class="gh-card-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="DD MMM YYYY"}}</time>
+                <span class="gh-card-duration">{{reading_time}}</span>
+                {{#if @site.comments_enabled}}
+                    {{comment_count class="gh-card-comments"}}
+                {{/if}}
+                {{^has visibility="public"}}
+                    {{> icons/star}}
+                {{/has}}
+            </footer>
+        </div>
     </a>
 </article>


### PR DESCRIPTION
## Summary
- display post feature images as square thumbnails alongside list items
- update card layout styling with responsive adjustments for the new media slot

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcb9923d74832bb736df72b64d3dba