### PR TITLE
Create hero-led magazine layout for homepage

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -22,19 +22,55 @@
     letter-spacing: 0.01em;
 }
 
-.gh-latest {
+.gh-hero {
     margin-top: 4rem;
-    margin-bottom: 12rem;
+    margin-bottom: 10rem;
 }
 
-.gh-latest .gh-card-meta {
-    margin-top: 2.4rem;
+.gh-hero-media {
+    position: relative;
+    margin: 0 0 2.8rem;
+    overflow: hidden;
+    border-radius: 1.6rem;
+    background-color: var(--color-light-gray);
+    aspect-ratio: 16 / 9;
+}
+
+.gh-latest-image {
+    width: 100%;
+    height: 100%;
+    display: block;
+    object-fit: cover;
+}
+
+.gh-hero-content {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.gh-hero .gh-card-title {
+    font-size: 5rem;
+    line-height: 1.05;
+}
+
+.gh-hero .gh-card-excerpt {
+    font-size: 2rem;
+    line-height: 1.6;
+    color: var(--color-darker-gray);
+}
+
+.gh-feed-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 2rem;
 }
 
 .gh-wrapper {
     display: grid;
-    grid-template-columns: 4fr 2fr;
-    column-gap: 2.4rem;
+    grid-template-columns: minmax(0, 4fr) minmax(0, 2fr);
+    column-gap: 3.2rem;
+    align-items: start;
 }
 
 .gh-wrapper > .gh-section {
@@ -59,32 +95,34 @@
     background-color: var(--color-light-gray);
 }
 
+.gh-card {
+    height: 100%;
+}
+
 .gh-card + .gh-card {
-    margin-top: 8rem;
+    margin-top: 0;
 }
 
 .gh-card-link {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 .gh-card-link-image {
-    display: flex;
-    gap: 2.4rem;
-    align-items: stretch;
+    gap: 0;
 }
 
-.gh-card-media {
+.gh-card-image {
     position: relative;
-    flex: 0 0 12rem;
-    width: 12rem;
-    aspect-ratio: 1 / 1;
-    margin: 0;
+    margin: 0 0 1.6rem;
     overflow: hidden;
     border-radius: 1.2rem;
     background-color: var(--color-light-gray);
+    aspect-ratio: 16 / 9;
 }
 
-.gh-card-thumbnail {
+.gh-card-image img {
     position: absolute;
     inset: 0;
     width: 100%;
@@ -93,7 +131,25 @@
 }
 
 .gh-card-content {
-    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    gap: 1.2rem;
+}
+
+.gh-card-tag {
+    align-self: flex-start;
+    padding: 0.4rem 1rem;
+    margin-bottom: 1.2rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    color: var(--ghost-accent-color);
+    text-transform: uppercase;
+    background-color: var(--color-white);
+    background-color: color-mix(in srgb, var(--ghost-accent-color) 12%, transparent);
+    border-radius: 999px;
+    border: 1px solid currentColor;
 }
 
 .gh-card-link:hover {
@@ -101,8 +157,9 @@
 }
 
 .gh-card-title {
-    font-size: 3.4rem;
+    font-size: 2.6rem;
     font-weight: 600;
+    line-height: 1.2;
     word-break: break-word;
 }
 
@@ -112,17 +169,19 @@
 
 .gh-card-excerpt {
     margin-top: 1.2rem;
-    font-size: 1.8rem;
-    line-height: 1.5;
-    letter-spacing: -0.01em;
+    font-size: 1.6rem;
+    line-height: 1.55;
+    letter-spacing: -0.005em;
     word-break: break-word;
+    color: var(--color-secondary-text);
 }
 
 .gh-card-meta {
     display: inline-flex;
     gap: 6px;
     align-items: center;
-    margin-top: 2rem;
+    margin-top: auto;
+    padding-top: 1.6rem;
     font-size: 1.2rem;
     font-weight: 500;
     line-height: 1;
@@ -174,12 +233,19 @@
     position: sticky;
     top: 4.8rem;
     height: max-content;
-    padding-left: 4rem;
+    padding-left: 3.2rem;
     font-size: 1.4rem;
+    line-height: 1.6;
 }
 
 .gh-sidebar .gh-section + .gh-section {
-    margin-top: 8rem;
+    margin-top: 6rem;
+}
+
+.gh-sidebar .gh-section-title {
+    margin-bottom: 1.6rem;
+    font-size: 1.1rem;
+    letter-spacing: 0.08em;
 }
 
 .gh-about {
@@ -597,25 +663,26 @@
 }
 
 @media (max-width: 767px) {
-    .gh-latest {
-        margin-bottom: 8rem;
+    .gh-hero {
+        margin: 2.4rem 0 6.4rem;
     }
 
-    .gh-card-link-image {
-        flex-direction: column;
+    .gh-hero-media {
+        margin-bottom: 2rem;
+        max-height: 260px;
     }
 
-    .gh-card-media {
-        width: 100%;
-        max-width: none;
+    .gh-hero .gh-card-title {
+        font-size: 3.8rem;
+    }
+
+    .gh-feed-grid {
+        grid-template-columns: 1fr;
     }
 
     .gh-wrapper {
         grid-template-columns: 1fr;
-    }
-
-    .gh-card + .gh-card {
-        margin-top: 6.4rem;
+        row-gap: 6.4rem;
     }
 
     .gh-loadmore {
@@ -624,7 +691,7 @@
 
     .gh-sidebar {
         padding-left: 0;
-        margin-top: 8rem;
+        margin-top: 6.4rem;
     }
 
     .gh-article-title {
@@ -672,7 +739,7 @@
 }
 
 @media (max-width: 991px) {
-    .gh-latest {
+    .gh-hero {
         margin-top: 0;
     }
 

--- a/index.hbs
+++ b/index.hbs
@@ -4,26 +4,41 @@
     <div class="gh-inner">
         {{^is "paged"}}
             {{#foreach posts limit="1"}}
-                <article class="gh-latest gh-card {{post_class}}">
+                <article class="gh-hero gh-card {{post_class}}">
                     <a class="gh-card-link" href="{{url}}">
-                        <header class="gh-card-header">
-                            <div class="gh-article-meta">
-                                <span class="gh-card-date">Latest — <time datetime="{{date format="YYYY-MM-DD"}}">{{date format="DD MMM YYYY"}}</time></span>
-                            </div>
-                            <h2 class="gh-article-title gh-card-title">{{title}}</h2>
-                        </header>
+                        {{#if feature_image}}
+                            <figure class="gh-hero-media">
+                                <img
+                                    class="gh-latest-image"
+                                    src="{{img_url feature_image size="xl"}}"
+                                    srcset="{{img_url feature_image size="s"}} 400w, {{img_url feature_image size="m"}} 720w, {{img_url feature_image size="l"}} 960w, {{img_url feature_image size="xl"}} 1200w"
+                                    sizes="(min-width: 992px) 960px, 100vw"
+                                    alt="{{title}}"
+                                    loading="lazy"
+                                >
+                            </figure>
+                        {{/if}}
 
-                        <p class="gh-article-excerpt">{{excerpt}}</p>
+                        <div class="gh-hero-content">
+                            <header class="gh-card-header">
+                                <div class="gh-article-meta">
+                                    <span class="gh-card-date">Latest — <time datetime="{{date format="YYYY-MM-DD"}}">{{date format="DD MMM YYYY"}}</time></span>
+                                </div>
+                                <h2 class="gh-article-title gh-card-title">{{title}}</h2>
+                            </header>
 
-                        <footer class="gh-card-meta">
-                            <span class="gh-card-duration">{{reading_time}}</span>
-                            {{#if @site.comments_enabled}}
-                                {{comment_count class="gh-card-comments"}}
-                            {{/if}}
-                            {{^has visibility="public"}}
-                                {{> icons/star}}
-                            {{/has}}
-                        </footer>
+                            <p class="gh-article-excerpt">{{excerpt}}</p>
+
+                            <footer class="gh-card-meta">
+                                <span class="gh-card-duration">{{reading_time}}</span>
+                                {{#if @site.comments_enabled}}
+                                    {{comment_count class="gh-card-comments"}}
+                                {{/if}}
+                                {{^has visibility="public"}}
+                                    {{> icons/star}}
+                                {{/has}}
+                            </footer>
+                        </div>
                     </a>
                 </article>
             {{/foreach}}
@@ -31,9 +46,9 @@
 
         <div class="gh-wrapper">
             <section class="gh-section">
-                <h2 class="gh-section-title">More issues</h2>
+                <h2 class="gh-section-title">More Issues</h2>
 
-                <div class="gh-feed">
+                <div class="gh-feed gh-feed-grid">
                     {{^is "paged"}}
                         {{#foreach posts from="2"}}
                             {{> loop}}

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -1,10 +1,11 @@
 <article class="gh-card {{post_class}}">
     <a class="gh-card-link{{#if feature_image}} gh-card-link-image{{/if}}" href="{{url}}">
         {{#if feature_image}}
-            <figure class="gh-card-media">
+            <figure class="gh-card-image">
                 <img
-                    class="gh-card-thumbnail"
-                    src="{{img_url feature_image size="s"}}"
+                    src="{{img_url feature_image size="m"}}"
+                    srcset="{{img_url feature_image size="s"}} 400w, {{img_url feature_image size="m"}} 720w, {{img_url feature_image size="l"}} 960w"
+                    sizes="(min-width: 1200px) 420px, (min-width: 768px) 50vw, 100vw"
                     alt="{{title}}"
                     loading="lazy"
                 >
@@ -12,6 +13,10 @@
         {{/if}}
 
         <div class="gh-card-content">
+            {{#if primary_tag}}
+                <span class="gh-card-tag">{{primary_tag.name}}</span>
+            {{/if}}
+
             <header class="gh-card-header">
                 <h2 class="gh-card-title">{{title}}</h2>
             </header>


### PR DESCRIPTION
## Summary
- feature the latest post in a hero block with a responsive feature image, metadata, and excerpt
- present remaining posts in a two-column card grid with tag labels and 16:9 feature imagery
- adjust sidebar spacing and global card styling to suit the updated magazine layout

## Testing
- not run (theme changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e0bc479d00832bb4e1465ae1a1a87e